### PR TITLE
Fix an issue pulling future boxscores

### DIFF
--- a/sportsreference/mlb/boxscore.py
+++ b/sportsreference/mlb/boxscore.py
@@ -1232,8 +1232,13 @@ class Boxscores:
         # The home team is the last (3rd) link in the boxscore
         home = links[-1]
         scores = re.findall(r'<td class="right">\d+</td>', str(game))
-        away_score = self._get_score(scores[0])
-        home_score = self._get_score(scores[1])
+        away_score = None
+        home_score = None
+        # If the game hasn't started or hasn't been updated on sports-reference
+        # yet, no score will be shown and therefore can't be parsed.
+        if len(scores) == 2:
+            away_score = self._get_score(scores[0])
+            home_score = self._get_score(scores[1])
         away_name, away_abbr = self._get_name(away)
         home_name, home_abbr = self._get_name(home)
         return (away_name, away_abbr, away_score, home_name, home_abbr,
@@ -1294,20 +1299,30 @@ class Boxscores:
                 home_score = details
             boxscore_url = game('td[class="right gamelink"] a')
             boxscore_uri = self._get_boxscore_uri(boxscore_url)
+            losers = [l for l in game('tr[class="loser"]').items()]
             winner = self._get_team_results(game('tr[class="winner"]'))
-            # Occurs when information couldn't be parsed from the boxscore and
-            # the game should be skipped to avoid conflicts populating the
-            # game information.
-            if not winner:
-                continue
-            winning_name, winning_abbreviation = winner
             loser = self._get_team_results(game('tr[class="loser"]'))
-            # Occurs when information couldn't be parsed from the boxscore and
-            # the game should be skipped to avoid conflicts populating the
-            # game information.
-            if not loser:
+            # Occurs when the boxscore format is invalid and the game should be
+            # skipped to avoid conflicts populating the game information.
+            if (len(losers) != 2 and loser and not winner) or \
+               (len(losers) != 2 and winner and not loser):
                 continue
-            losing_name, losing_abbreviation = loser
+            # Occurs when information couldn't be parsed from the boxscore or
+            # the game hasn't occurred yet. In this case, the winner should be
+            # None to avoid conflicts.
+            if not winner or len(losers) == 2:
+                winning_name = None
+                winning_abbreviation = None
+            else:
+                winning_name, winning_abbreviation = winner
+            # Occurs when information couldn't be parsed from the boxscore or
+            # the game hasn't occurred yet. In this case, the winner should be
+            # None to avoid conflicts.
+            if not loser or len(losers) == 2:
+                losing_name = None
+                losing_abbreviation = None
+            else:
+                losing_name, losing_abbreviation = loser
             game_info = {
                 'boxscore': boxscore_uri,
                 'away_name': away_name,

--- a/sportsreference/nba/boxscore.py
+++ b/sportsreference/nba/boxscore.py
@@ -1254,8 +1254,13 @@ class Boxscores:
         # The home team is the last (3rd) link in the boxscore
         home = links[-1]
         scores = re.findall(r'<td class="right">\d+</td>', str(game))
-        away_score = self._get_score(scores[0])
-        home_score = self._get_score(scores[1])
+        away_score = None
+        home_score = None
+        # If the game hasn't started or hasn't been updated on sports-reference
+        # yet, no score will be shown and therefore can't be parsed.
+        if len(scores) == 2:
+            away_score = self._get_score(scores[0])
+            home_score = self._get_score(scores[1])
         away_name, away_abbr = self._get_name(away)
         home_name, home_abbr = self._get_name(home)
         return (away_name, away_abbr, away_score, home_name, home_abbr,
@@ -1316,20 +1321,30 @@ class Boxscores:
                 home_score = details
             boxscore_url = game('td[class="right gamelink"] a')
             boxscore_uri = self._get_boxscore_uri(boxscore_url)
+            losers = [l for l in game('tr[class="loser"]').items()]
             winner = self._get_team_results(game('tr[class="winner"]'))
-            # Occurs when information couldn't be parsed from the boxscore and
-            # the game should be skipped to avoid conflicts populating the
-            # game information.
-            if not winner:
-                continue
-            winning_name, winning_abbreviation = winner
             loser = self._get_team_results(game('tr[class="loser"]'))
-            # Occurs when information couldn't be parsed from the boxscore and
-            # the game should be skipped to avoid conflicts populating the
-            # game information.
-            if not loser:
+            # Occurs when the boxscore format is invalid and the game should be
+            # skipped to avoid conflicts populating the game information.
+            if (len(losers) != 2 and loser and not winner) or \
+               (len(losers) != 2 and winner and not loser):
                 continue
-            losing_name, losing_abbreviation = loser
+            # Occurs when information couldn't be parsed from the boxscore or
+            # the game hasn't occurred yet. In this case, the winner should be
+            # None to avoid conflicts.
+            if not winner or len(losers) == 2:
+                winning_name = None
+                winning_abbreviation = None
+            else:
+                winning_name, winning_abbreviation = winner
+            # Occurs when information couldn't be parsed from the boxscore or
+            # the game hasn't occurred yet. In this case, the winner should be
+            # None to avoid conflicts.
+            if not loser or len(losers) == 2:
+                losing_name = None
+                losing_abbreviation = None
+            else:
+                losing_name, losing_abbreviation = loser
             game_info = {
                 'boxscore': boxscore_uri,
                 'away_name': away_name,

--- a/sportsreference/ncaab/boxscore.py
+++ b/sportsreference/ncaab/boxscore.py
@@ -1455,8 +1455,13 @@ class Boxscores:
         home = links[-1]
         non_di = False
         scores = re.findall(r'<td class="right">\d+</td>', str(game))
-        away_score = self._get_score(scores[0])
-        home_score = self._get_score(scores[1])
+        away_score = None
+        home_score = None
+        # If the game hasn't started or hasn't been updated on sports-reference
+        # yet, no score will be shown and therefore can't be parsed.
+        if len(scores) == 2:
+            away_score = self._get_score(scores[0])
+            home_score = self._get_score(scores[1])
         away_name, away_abbr, away_non_di = self._get_name(away('a'))
         home_name, home_abbr, home_non_di = self._get_name(home('a'))
         non_di = away_non_di or home_non_di

--- a/sportsreference/ncaaf/boxscore.py
+++ b/sportsreference/ncaaf/boxscore.py
@@ -897,8 +897,13 @@ class Boxscores:
         home = links[-1]
         non_di = False
         scores = re.findall(r'<td class="right">\d+</td>', str(game))
-        away_score = self._get_score(scores[0])
-        home_score = self._get_score(scores[1])
+        away_score = None
+        home_score = None
+        # If the game hasn't started or hasn't been updated on sports-reference
+        # yet, no score will be shown and therefore can't be parsed.
+        if len(scores) == 2:
+            away_score = self._get_score(scores[0])
+            home_score = self._get_score(scores[1])
         away_name, away_abbr, away_non_di = self._get_name(away('a'))
         home_name, home_abbr, home_non_di = self._get_name(home('a'))
         non_di = away_non_di or home_non_di

--- a/sportsreference/nfl/boxscore.py
+++ b/sportsreference/nfl/boxscore.py
@@ -1005,8 +1005,13 @@ class Boxscores:
         # The home team is the last (3rd) link in the boxscore
         home = links[-1]
         scores = re.findall(r'<td class="right">\d+</td>', str(game))
-        away_score = self._get_score(scores[0])
-        home_score = self._get_score(scores[1])
+        away_score = None
+        home_score = None
+        # If the game hasn't started or hasn't been updated on sports-reference
+        # yet, no score will be shown and therefore can't be parsed.
+        if len(scores) == 2:
+            away_score = self._get_score(scores[0])
+            home_score = self._get_score(scores[1])
         away_name, away_abbr = self._get_name(away)
         home_name, home_abbr = self._get_name(home)
         return (away_name, away_abbr, away_score, home_name, home_abbr,
@@ -1067,20 +1072,30 @@ class Boxscores:
                 home_score = details
             boxscore_url = game('td[class="right gamelink"] a')
             boxscore_uri = self._get_boxscore_uri(boxscore_url)
+            losers = [l for l in game('tr[class="loser"]').items()]
             winner = self._get_team_results(game('tr[class="winner"]'))
-            # Occurs when information couldn't be parsed from the boxscore and
-            # the game should be skipped to avoid conflicts populating the
-            # game information.
-            if not winner:
-                continue
-            winning_name, winning_abbreviation = winner
             loser = self._get_team_results(game('tr[class="loser"]'))
-            # Occurs when information couldn't be parsed from the boxscore and
-            # the game should be skipped to avoid conflicts populating the
-            # game information.
-            if not loser:
+            # Occurs when the boxscore format is invalid and the game should be
+            # skipped to avoid conflicts populating the game information.
+            if (len(losers) != 2 and loser and not winner) or \
+               (len(losers) != 2 and winner and not loser):
                 continue
-            losing_name, losing_abbreviation = loser
+            # Occurs when information couldn't be parsed from the boxscore or
+            # the game hasn't occurred yet. In this case, the winner should be
+            # None to avoid conflicts.
+            if not winner or len(losers) == 2:
+                winning_name = None
+                winning_abbreviation = None
+            else:
+                winning_name, winning_abbreviation = winner
+            # Occurs when information couldn't be parsed from the boxscore or
+            # the game hasn't occurred yet. In this case, the winner should be
+            # None to avoid conflicts.
+            if not loser or len(losers) == 2:
+                losing_name = None
+                losing_abbreviation = None
+            else:
+                losing_name, losing_abbreviation = loser
             game_info = {
                 'boxscore': boxscore_uri,
                 'away_name': away_name,

--- a/sportsreference/nhl/boxscore.py
+++ b/sportsreference/nhl/boxscore.py
@@ -917,8 +917,13 @@ class Boxscores:
         # The home team is the last (3rd) link in the boxscore
         home = links[-1]
         scores = re.findall(r'<td class="right">\d+</td>', str(game))
-        away_score = self._get_score(scores[0])
-        home_score = self._get_score(scores[1])
+        away_score = None
+        home_score = None
+        # If the game hasn't started or hasn't been updated on sports-reference
+        # yet, no score will be shown and therefore can't be parsed.
+        if len(scores) == 2:
+            away_score = self._get_score(scores[0])
+            home_score = self._get_score(scores[1])
         away_name, away_abbr = self._get_name(away)
         home_name, home_abbr = self._get_name(home)
         return (away_name, away_abbr, away_score, home_name, home_abbr,
@@ -979,20 +984,30 @@ class Boxscores:
                 home_score = details
             boxscore_url = game('td[class="right gamelink"] a')
             boxscore_uri = self._get_boxscore_uri(boxscore_url)
+            losers = [l for l in game('tr[class="loser"]').items()]
             winner = self._get_team_results(game('tr[class="winner"]'))
-            # Occurs when information couldn't be parsed from the boxscore and
-            # the game should be skipped to avoid conflicts populating the
-            # game information.
-            if not winner:
-                continue
-            winning_name, winning_abbreviation = winner
             loser = self._get_team_results(game('tr[class="loser"]'))
-            # Occurs when information couldn't be parsed from the boxscore and
-            # the game should be skipped to avoid conflicts populating the
-            # game information.
-            if not loser:
+            # Occurs when the boxscore format is invalid and the game should be
+            # skipped to avoid conflicts populating the game information.
+            if (len(losers) != 2 and loser and not winner) or \
+               (len(losers) != 2 and winner and not loser):
                 continue
-            losing_name, losing_abbreviation = loser
+            # Occurs when information couldn't be parsed from the boxscore or
+            # the game hasn't occurred yet. In this case, the winner should be
+            # None to avoid conflicts.
+            if not winner or len(losers) == 2:
+                winning_name = None
+                winning_abbreviation = None
+            else:
+                winning_name, winning_abbreviation = winner
+            # Occurs when information couldn't be parsed from the boxscore or
+            # the game hasn't occurred yet. In this case, the winner should be
+            # None to avoid conflicts.
+            if not loser or len(losers) == 2:
+                losing_name = None
+                losing_abbreviation = None
+            else:
+                losing_name, losing_abbreviation = loser
             game_info = {
                 'boxscore': boxscore_uri,
                 'away_name': away_name,

--- a/tests/unit/test_mlb_boxscore.py
+++ b/tests/unit/test_mlb_boxscore.py
@@ -320,14 +320,14 @@ class TestMLBBoxscores:
     @patch('requests.get', side_effect=mock_pyquery)
     def setup_method(self, *args, **kwargs):
         flexmock(Boxscores) \
-            .should_receive('_get_team_details') \
-            .and_return((None, None, None, None, None, None))
-        flexmock(Boxscores) \
             .should_receive('_find_games') \
             .and_return(None)
         self.boxscores = Boxscores(None)
 
     def test_improper_loser_boxscore_format_skips_game(self):
+        flexmock(Boxscores) \
+            .should_receive('_get_team_details') \
+            .and_return((None, None, None, None, None, None))
         mock_html = pq("""<table class="teams">
 <tbody>
 <tr class="loser">
@@ -348,6 +348,9 @@ class TestMLBBoxscores:
         assert len(games) == 0
 
     def test_improper_winner_boxscore_format_skips_game(self):
+        flexmock(Boxscores) \
+            .should_receive('_get_team_details') \
+            .and_return((None, None, None, None, None, None))
         mock_html = pq("""<table class="teams">
 <tbody>
 <tr class="loser">
@@ -367,3 +370,37 @@ class TestMLBBoxscores:
         games = self.boxscores._extract_game_info([mock_html])
 
         assert len(games) == 0
+
+    def test_boxscore_with_no_score_returns_none(self):
+        mock_html = pq("""<table class="teams">
+<tbody>
+<tr class="loser">
+    <td><a href="/teams/TEX/2017.shtml">Texas Rangers</a></td>
+    <td class="right gamelink">
+        <a href="/boxes/BAL/BAL201707170.shtml">Final</a>
+    </td>
+</tr>
+<tr class="loser">
+    <td><a href="/teams/BAL/2017.shtml">Baltimore Orioles</a></td>
+    <td class="right">
+    </td>
+</tr>
+</tbody>
+</table>""")
+        games = self.boxscores._extract_game_info([mock_html])
+
+        assert games == [
+            {
+                'away_abbr': 'TEX',
+                'away_name': 'Texas Rangers',
+                'away_score': None,
+                'boxscore': 'BAL/BAL201707170',
+                'home_abbr': 'BAL',
+                'home_name': 'Baltimore Orioles',
+                'home_score': None,
+                'losing_abbr': None,
+                'losing_name': None,
+                'winning_abbr': None,
+                'winning_name': None
+            }
+        ]

--- a/tests/unit/test_nhl_boxscore.py
+++ b/tests/unit/test_nhl_boxscore.py
@@ -505,14 +505,14 @@ class TestMLBBoxscores:
     @patch('requests.get', side_effect=mock_pyquery)
     def setup_method(self, *args, **kwargs):
         flexmock(Boxscores) \
-            .should_receive('_get_team_details') \
-            .and_return((None, None, None, None, None, None))
-        flexmock(Boxscores) \
             .should_receive('_find_games') \
             .and_return(None)
         self.boxscores = Boxscores(None)
 
     def test_improper_loser_boxscore_format_skips_game(self):
+        flexmock(Boxscores) \
+            .should_receive('_get_team_details') \
+            .and_return((None, None, None, None, None, None))
         mock_html = pq("""<table class="teams">
 <tbody>
 <tr class="loser">
@@ -533,6 +533,9 @@ class TestMLBBoxscores:
         assert len(games) == 0
 
     def test_improper_winner_boxscore_format_skips_game(self):
+        flexmock(Boxscores) \
+            .should_receive('_get_team_details') \
+            .and_return((None, None, None, None, None, None))
         mock_html = pq("""<table class="teams">
 <tbody>
 <tr class="loser">
@@ -552,3 +555,37 @@ class TestMLBBoxscores:
         games = self.boxscores._extract_game_info([mock_html])
 
         assert len(games) == 0
+
+    def test_boxscore_with_no_score_returns_none(self):
+        mock_html = pq("""<table class="teams">
+<tbody>
+<tr class="loser">
+    <td><a href="/teams/LAK/2019.html">Los Angeles Kings</a></td>
+    <td class="right gamelink">
+        <a href="/boxscores/201812100DET.html">Final</a>
+    </td>
+</tr>
+<tr class="loser">
+    <td><a href="/teams/DET/2019.html">Detroit Red Wings</a></td>
+    <td class="right">&nbsp;
+    </td>
+</tr>
+</tbody>
+</table>""")
+        games = self.boxscores._extract_game_info([mock_html])
+
+        assert games == [
+            {
+                'away_abbr': 'LAK',
+                'away_name': 'Los Angeles Kings',
+                'away_score': None,
+                'boxscore': '201812100DET',
+                'home_abbr': 'DET',
+                'home_name': 'Detroit Red Wings',
+                'home_score': None,
+                'losing_abbr': None,
+                'losing_name': None,
+                'winning_abbr': None,
+                'winning_name': None
+            }
+        ]


### PR DESCRIPTION
An error is currently thrown whenever the boxscore of a game that hasn't completed (for example, any future games and games on the current day) is requested from sportsreference as it tries to parse a score when none exists. Instead of throwing an error, the score should just show as None.

Fixes #22

Signed-Off-By: Robert Clark <robdclark@outlook.com>