### PR TITLE
Adds leagues for seasons with multiple leagues

### DIFF
--- a/sportsreference/nba/teams.py
+++ b/sportsreference/nba/teams.py
@@ -33,10 +33,17 @@ class Team:
         Teams class.
     year : string (optional)
         The requested year to pull stats from.
+    league: string (optional)
+        The league of the requested team. Some years, especially earlier years,
+        have multiple basketball leagues (like the BAA, etc.) If None is
+        specified, all teams from all leagues are considered.
     """
-    def __init__(self, team_name=None, team_data=None, rank=None, year=None):
+
+    def __init__(self, team_name=None, team_data=None, rank=None, year=None,
+                 league=None):
         self._year = year
         self._rank = rank
+        self._league = league
         self._abbreviation = None
         self._name = None
         self._games_played = None
@@ -114,6 +121,7 @@ class Team:
         self._year = year
         team_data = team_data_dict[team_name]['data']
         self._rank = team_data_dict[team_name]['rank']
+        self._league = team_data_dict[team_name]['league']
         return team_data
 
     def _parse_team_data(self, team_data):
@@ -138,8 +146,7 @@ class Team:
         for field in self.__dict__:
             # The rank attribute is passed directly to the class during
             # instantiation.
-            if field == '_rank' or \
-               field == '_year':
+            if field in ['_rank', '_year', '_league']:
                 continue
             value = utils._parse_field(PARSING_SCHEME,
                                        team_data,
@@ -165,6 +172,7 @@ class Team:
             'free_throw_percentage': self.free_throw_percentage,
             'free_throws': self.free_throws,
             'games_played': self.games_played,
+            'league': self.league,
             'minutes_played': self.minutes_played,
             'name': self.name,
             'offensive_rebounds': self.offensive_rebounds,
@@ -251,6 +259,13 @@ class Team:
         Pistons'.
         """
         return self._name
+
+    @property
+    def league(self):
+        """Returns a ``string`` of the league that the team is in, such as
+        'NBA' or 'BAA'
+        """
+        return self._league
 
     @int_property_decorator
     def games_played(self):
@@ -620,11 +635,17 @@ class Teams:
     ----------
     year : string (optional)
         The requested year to pull stats from.
+
+    leagues: list [string] (optional)
+        A list of leagues to consider. Some years, especially earlier years,
+        have multiple basketball leagues (like the BAA, etc.) If None is
+        specified, all teams from all leagues are returned.
     """
-    def __init__(self, year=None):
+
+    def __init__(self, year=None, leagues=None):
         self._teams = []
 
-        team_data_dict, year = _retrieve_all_teams(year)
+        team_data_dict, year = _retrieve_all_teams(year, leagues=leagues)
         self._instantiate_teams(team_data_dict, year)
 
     def __getitem__(self, abbreviation):
@@ -708,7 +729,7 @@ class Teams:
         for team_data in team_data_dict.values():
             team = Team(team_data=team_data['data'],
                         rank=team_data['rank'],
-                        year=year)
+                        year=year, league=team_data['league'])
             self._teams.append(team)
 
     @property

--- a/sportsreference/nfl/nfl_utils.py
+++ b/sportsreference/nfl/nfl_utils.py
@@ -1,9 +1,85 @@
-from pyquery import PyQuery as pq
-from sportsreference import utils
 from .constants import PARSING_SCHEME, SEASON_PAGE_URL
+from sportsreference import utils
+from pyquery import PyQuery as pq
 
 
-def _add_stats_data(teams_list, team_data_dict):
+def _determine_leagues_from_year(year):
+    """Determines the potential leagues from the year.
+
+    Parameters
+    ----------
+    year: string
+        A ``string`` representing the year that the data is relevant for.
+
+
+    Returns
+    -------
+    list
+        A ``list`` of strings referencing the leagues present in that year.
+    """
+    if 1960 <= year <= 1969:
+        leagues = ['NFL', 'AFL']
+    elif 1946 <= year <= 1949:
+        leagues = ['NFL', 'AAFC']
+    elif 1950 <= year <= 1959:
+        leagues = ['NFL']
+    elif 1920 <= year <= 1921:
+        leagues = ['APFA']
+    else:
+        leagues = ['NFL']
+    return leagues
+
+
+def _determine_divs_from_year_league(year, league):
+    """Determines the correct divs to search for given a particular
+    year and league.
+
+
+    Parameters
+    ----------
+    year: string
+        A ``string`` representing the year that the data is relevant for.
+
+    league: string
+        A ``string`` representing the league that is desired to pull from.
+        For instance, 'NFL' or 'AFL'.
+
+    Returns:
+        list [string]: a list of strings containing the divs to use.
+    """
+    year_int = int(year)
+
+    if year_int > 1969:
+        divs = ['div#all_team_stats', 'table#AFC', 'table#NFC']
+    else:
+        divs = ['div#all_team_stats',
+                'table#{league}'.format(**dict(league=league))]
+    return divs
+
+
+def _generate_season_page_url(year, league):
+    """Generates the URL representing a particular league
+
+    Parameters
+    ----------
+    year: string
+        A ``string`` representing the year that the data is relevant for.
+
+    league: string
+        A ``string`` representing the league to search for teams.
+
+    Returns
+    -------
+    PyQuery Object
+        A PyQuery Object reprenting the url for the particular league and year.
+    """
+    if league == 'NFL':
+        return pq(SEASON_PAGE_URL % year)
+    else:
+        return pq(SEASON_PAGE_URL % (year + '_' + league))
+
+
+def _add_stats_data(teams_list, team_data_dict, league):
     """
     Add a team's stats row to a dictionary.
 
@@ -35,12 +111,14 @@ def _add_stats_data(teams_list, team_data_dict):
         try:
             team_data_dict[abbr]['data'] += team_data
         except KeyError:
-            team_data_dict[abbr] = {'data': team_data, 'rank': rank}
+            team_data_dict[abbr] = {'data': team_data,
+                                    'rank': rank,
+                                    'league': league}
         rank += 1
     return team_data_dict
 
 
-def _retrieve_all_teams(year):
+def _retrieve_all_teams(year, leagues=None):
     """
     Find and create Team instances for all teams in the given season.
 
@@ -75,13 +153,21 @@ def _retrieve_all_teams(year):
         if not utils._url_exists(SEASON_PAGE_URL % year) and \
            utils._url_exists(SEASON_PAGE_URL % str(int(year) - 1)):
             year = str(int(year) - 1)
-    doc = pq(SEASON_PAGE_URL % year)
-    teams_list = utils._get_stats_table(doc, 'div#all_team_stats')
-    afc_list = utils._get_stats_table(doc, 'table#AFC')
-    nfc_list = utils._get_stats_table(doc, 'table#NFC')
-    if not teams_list and not afc_list and not nfc_list:
+
+    if not leagues:
+        leagues = _determine_leagues_from_year(int(year))
+    for league in leagues:
+        url = _generate_season_page_url(year, league)
+        divs = _determine_divs_from_year_league(year, league)
+
+        for div in divs:
+            table = utils._get_stats_table(url, div)
+            if table is not None:
+                team_data_dict = _add_stats_data(
+                    table, team_data_dict, league)
+
+    if len(team_data_dict) == 0:
         utils._no_data_found()
         return None, None
-    for stats_list in [teams_list, afc_list, nfc_list]:
-        team_data_dict = _add_stats_data(stats_list, team_data_dict)
+
     return team_data_dict, year

--- a/sportsreference/nfl/roster.py
+++ b/sportsreference/nfl/roster.py
@@ -76,6 +76,7 @@ class Player(AbstractPlayer):
         is a number starting at '00' for the first time that player ID has been
         used and increments by 1 for every successive player.
     """
+
     def __init__(self, player_id):
         self._most_recent_season = ''
         self._index = None
@@ -217,7 +218,7 @@ class Player(AbstractPlayer):
         """
         # The first letter of the player's last name is used to sort the player
         # list and is a part of the URL.
-        first_character = self._player_id[0]
+        first_character = self._player_id[0].upper()
         return PLAYER_URL % (first_character, self._player_id)
 
     def _retrieve_html_page(self):
@@ -1492,6 +1493,7 @@ class Roster:
         respective stats which greatly reduces the time to return a response if
         just the names and IDs are desired. Defaults to False.
     """
+
     def __init__(self, team, year=None, slim=False):
         self._team = team
         self._slim = slim

--- a/sportsreference/nfl/schedule.py
+++ b/sportsreference/nfl/schedule.py
@@ -42,6 +42,7 @@ class Game:
         2017 season took place in early Feburary 2018, but 2017 should be
         passed as that was the year the bulk of the season was played in.
     """
+
     def __init__(self, game_data, game_type, year):
         self._year = year
         self._week = None
@@ -563,6 +564,7 @@ class Schedule:
     year : string (optional)
         The requested year to pull stats from.
     """
+
     def __init__(self, abbreviation, year=None):
         self._games = []
         self._pull_schedule(abbreviation, year)

--- a/tests/integration/boxscore/test_nfl_boxscore.py
+++ b/tests/integration/boxscore/test_nfl_boxscore.py
@@ -7,7 +7,7 @@ from sportsreference import utils
 from sportsreference.constants import AWAY
 from sportsreference.nfl.constants import BOXSCORE_URL, BOXSCORES_URL
 from sportsreference.nfl.boxscore import Boxscore, Boxscores
-
+from copy import deepcopy
 
 MONTH = 10
 YEAR = 2017
@@ -31,6 +31,8 @@ def mock_pyquery(url):
         return MockPQ(read_file('boxscores-7-2017.html'))
     if url == BOXSCORES_URL % (YEAR, 8):
         return MockPQ(read_file('boxscores-8-2017.html'))
+    if 'years' in url:
+        return MockPQ(read_file('boxscores-7-2017.html'))
     boxscore = read_file('%s.html' % BOXSCORE)
     return MockPQ(boxscore)
 
@@ -162,6 +164,7 @@ class TestNFLBoxscores:
         self.expected = {
             '7-2017': [
                 {'boxscore': '201710190rai',
+                 'league': 'NFL',
                  'away_name': 'Kansas City Chiefs',
                  'away_abbr': 'kan',
                  'away_score': 30,
@@ -173,6 +176,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Kansas City Chiefs',
                  'losing_abbr': 'kan'},
                 {'boxscore': '201710220chi',
+                 'league': 'NFL',
                  'away_name': 'Carolina Panthers',
                  'away_abbr': 'car',
                  'away_score': 3,
@@ -184,6 +188,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Carolina Panthers',
                  'losing_abbr': 'car'},
                 {'boxscore': '201710220buf',
+                 'league': 'NFL',
                  'away_name': 'Tampa Bay Buccaneers',
                  'away_abbr': 'tam',
                  'away_score': 27,
@@ -195,6 +200,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Tampa Bay Buccaneers',
                  'losing_abbr': 'tam'},
                 {'boxscore': '201710220ram',
+                 'league': 'NFL',
                  'away_name': 'Arizona Cardinals',
                  'away_abbr': 'crd',
                  'away_score': 0,
@@ -206,6 +212,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Arizona Cardinals',
                  'losing_abbr': 'crd'},
                 {'boxscore': '201710220min',
+                 'league': 'NFL',
                  'away_name': 'Baltimore Ravens',
                  'away_abbr': 'rav',
                  'away_score': 16,
@@ -217,6 +224,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Baltimore Ravens',
                  'losing_abbr': 'rav'},
                 {'boxscore': '201710220mia',
+                 'league': 'NFL',
                  'away_name': 'New York Jets',
                  'away_abbr': 'nyj',
                  'away_score': 28,
@@ -228,6 +236,7 @@ class TestNFLBoxscores:
                  'losing_name': 'New York Jets',
                  'losing_abbr': 'nyj'},
                 {'boxscore': '201710220gnb',
+                 'league': 'NFL',
                  'away_name': 'New Orleans Saints',
                  'away_abbr': 'nor',
                  'away_score': 26,
@@ -239,6 +248,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Green Bay Packers',
                  'losing_abbr': 'gnb'},
                 {'boxscore': '201710220clt',
+                 'league': 'NFL',
                  'away_name': 'Jacksonville Jaguars',
                  'away_abbr': 'jax',
                  'away_score': 27,
@@ -250,6 +260,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Indianapolis Colts',
                  'losing_abbr': 'clt'},
                 {'boxscore': '201710220cle',
+                 'league': 'NFL',
                  'away_name': 'Tennessee Titans',
                  'away_abbr': 'oti',
                  'away_score': 12,
@@ -261,6 +272,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Cleveland Browns',
                  'losing_abbr': 'cle'},
                 {'boxscore': '201710220sfo',
+                 'league': 'NFL',
                  'away_name': 'Dallas Cowboys',
                  'away_abbr': 'dal',
                  'away_score': 40,
@@ -272,6 +284,7 @@ class TestNFLBoxscores:
                  'losing_name': 'San Francisco 49ers',
                  'losing_abbr': 'sfo'},
                 {'boxscore': '201710220sdg',
+                 'league': 'NFL',
                  'away_name': 'Denver Broncos',
                  'away_abbr': 'den',
                  'away_score': 0,
@@ -283,6 +296,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Denver Broncos',
                  'losing_abbr': 'den'},
                 {'boxscore': '201710220pit',
+                 'league': 'NFL',
                  'away_name': 'Cincinnati Bengals',
                  'away_abbr': 'cin',
                  'away_score': 14,
@@ -294,6 +308,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Cincinnati Bengals',
                  'losing_abbr': 'cin'},
                 {'boxscore': '201710220nyg',
+                 'league': 'NFL',
                  'away_name': 'Seattle Seahawks',
                  'away_abbr': 'sea',
                  'away_score': 24,
@@ -305,6 +320,7 @@ class TestNFLBoxscores:
                  'losing_name': 'New York Giants',
                  'losing_abbr': 'nyg'},
                 {'boxscore': '201710220nwe',
+                 'league': 'NFL',
                  'away_name': 'Atlanta Falcons',
                  'away_abbr': 'atl',
                  'away_score': 7,
@@ -316,6 +332,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Atlanta Falcons',
                  'losing_abbr': 'atl'},
                 {'boxscore': '201710230phi',
+                 'league': 'NFL',
                  'away_name': 'Washington Redskins',
                  'away_abbr': 'was',
                  'away_score': 24,
@@ -342,10 +359,34 @@ class TestNFLBoxscores:
         assert result == self.expected
 
     @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_boxscores_leagues(self, *args, **kwargs):
+        year_to_leagues = {
+            1961: ['NFL', 'AFL'],
+            1948: ['NFL', 'AAFC'],
+            1955: ['NFL'],
+            1921: ['APFA'],
+            2019: ['NFL']
+        }
+
+        for year, leagues in year_to_leagues.items():
+            test_bss = Boxscores(1, year).games
+            month_year = '1-{year}'.format(**dict(year=year))
+            exp = {month_year: []}
+            for l in leagues:
+                e = {
+                    month_year: deepcopy(self.expected['7-2017'])
+                }
+                for e_i in e[month_year]:
+                    e_i['league'] = l
+                exp[month_year] += e[month_year]
+            assert test_bss == exp
+
+    @mock.patch('requests.get', side_effect=mock_pyquery)
     def test_boxscores_search_multiple_weeks(self, *args, **kwargs):
         expected = {
             '7-2017': [
                 {'boxscore': '201710190rai',
+                 'league': 'NFL',
                  'away_name': 'Kansas City Chiefs',
                  'away_abbr': 'kan',
                  'away_score': 30,
@@ -357,6 +398,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Kansas City Chiefs',
                  'losing_abbr': 'kan'},
                 {'boxscore': '201710220chi',
+                 'league': 'NFL',
                  'away_name': 'Carolina Panthers',
                  'away_abbr': 'car',
                  'away_score': 3,
@@ -368,6 +410,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Carolina Panthers',
                  'losing_abbr': 'car'},
                 {'boxscore': '201710220buf',
+                 'league': 'NFL',
                  'away_name': 'Tampa Bay Buccaneers',
                  'away_abbr': 'tam',
                  'away_score': 27,
@@ -379,6 +422,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Tampa Bay Buccaneers',
                  'losing_abbr': 'tam'},
                 {'boxscore': '201710220ram',
+                 'league': 'NFL',
                  'away_name': 'Arizona Cardinals',
                  'away_abbr': 'crd',
                  'away_score': 0,
@@ -390,6 +434,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Arizona Cardinals',
                  'losing_abbr': 'crd'},
                 {'boxscore': '201710220min',
+                 'league': 'NFL',
                  'away_name': 'Baltimore Ravens',
                  'away_abbr': 'rav',
                  'away_score': 16,
@@ -401,6 +446,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Baltimore Ravens',
                  'losing_abbr': 'rav'},
                 {'boxscore': '201710220mia',
+                 'league': 'NFL',
                  'away_name': 'New York Jets',
                  'away_abbr': 'nyj',
                  'away_score': 28,
@@ -412,6 +458,7 @@ class TestNFLBoxscores:
                  'losing_name': 'New York Jets',
                  'losing_abbr': 'nyj'},
                 {'boxscore': '201710220gnb',
+                 'league': 'NFL',
                  'away_name': 'New Orleans Saints',
                  'away_abbr': 'nor',
                  'away_score': 26,
@@ -423,6 +470,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Green Bay Packers',
                  'losing_abbr': 'gnb'},
                 {'boxscore': '201710220clt',
+                 'league': 'NFL',
                  'away_name': 'Jacksonville Jaguars',
                  'away_abbr': 'jax',
                  'away_score': 27,
@@ -434,6 +482,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Indianapolis Colts',
                  'losing_abbr': 'clt'},
                 {'boxscore': '201710220cle',
+                 'league': 'NFL',
                  'away_name': 'Tennessee Titans',
                  'away_abbr': 'oti',
                  'away_score': 12,
@@ -445,6 +494,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Cleveland Browns',
                  'losing_abbr': 'cle'},
                 {'boxscore': '201710220sfo',
+                 'league': 'NFL',
                  'away_name': 'Dallas Cowboys',
                  'away_abbr': 'dal',
                  'away_score': 40,
@@ -456,6 +506,7 @@ class TestNFLBoxscores:
                  'losing_name': 'San Francisco 49ers',
                  'losing_abbr': 'sfo'},
                 {'boxscore': '201710220sdg',
+                 'league': 'NFL',
                  'away_name': 'Denver Broncos',
                  'away_abbr': 'den',
                  'away_score': 0,
@@ -467,6 +518,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Denver Broncos',
                  'losing_abbr': 'den'},
                 {'boxscore': '201710220pit',
+                 'league': 'NFL',
                  'away_name': 'Cincinnati Bengals',
                  'away_abbr': 'cin',
                  'away_score': 14,
@@ -478,6 +530,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Cincinnati Bengals',
                  'losing_abbr': 'cin'},
                 {'boxscore': '201710220nyg',
+                 'league': 'NFL',
                  'away_name': 'Seattle Seahawks',
                  'away_abbr': 'sea',
                  'away_score': 24,
@@ -489,6 +542,7 @@ class TestNFLBoxscores:
                  'losing_name': 'New York Giants',
                  'losing_abbr': 'nyg'},
                 {'boxscore': '201710220nwe',
+                 'league': 'NFL',
                  'away_name': 'Atlanta Falcons',
                  'away_abbr': 'atl',
                  'away_score': 7,
@@ -500,6 +554,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Atlanta Falcons',
                  'losing_abbr': 'atl'},
                 {'boxscore': '201710230phi',
+                 'league': 'NFL',
                  'away_name': 'Washington Redskins',
                  'away_abbr': 'was',
                  'away_score': 24,
@@ -513,6 +568,7 @@ class TestNFLBoxscores:
             ],
             '8-2017': [
                 {'boxscore': '201710260rav',
+                 'league': 'NFL',
                  'away_name': 'Miami Dolphins',
                  'away_abbr': 'mia',
                  'away_score': 0,
@@ -524,6 +580,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Miami Dolphins',
                  'losing_abbr': 'mia'},
                 {'boxscore': '201710290cle',
+                 'league': 'NFL',
                  'away_name': 'Minnesota Vikings',
                  'away_abbr': 'min',
                  'away_score': 33,
@@ -535,6 +592,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Cleveland Browns',
                  'losing_abbr': 'cle'},
                 {'boxscore': '201710290buf',
+                 'league': 'NFL',
                  'away_name': 'Oakland Raiders',
                  'away_abbr': 'rai',
                  'away_score': 14,
@@ -546,6 +604,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Oakland Raiders',
                  'losing_abbr': 'rai'},
                 {'boxscore': '201710290tam',
+                 'league': 'NFL',
                  'away_name': 'Carolina Panthers',
                  'away_abbr': 'car',
                  'away_score': 17,
@@ -557,6 +616,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Tampa Bay Buccaneers',
                  'losing_abbr': 'tam'},
                 {'boxscore': '201710290phi',
+                 'league': 'NFL',
                  'away_name': 'San Francisco 49ers',
                  'away_abbr': 'sfo',
                  'away_score': 10,
@@ -568,6 +628,7 @@ class TestNFLBoxscores:
                  'losing_name': 'San Francisco 49ers',
                  'losing_abbr': 'sfo'},
                 {'boxscore': '201710290nyj',
+                 'league': 'NFL',
                  'away_name': 'Atlanta Falcons',
                  'away_abbr': 'atl',
                  'away_score': 25,
@@ -579,6 +640,7 @@ class TestNFLBoxscores:
                  'losing_name': 'New York Jets',
                  'losing_abbr': 'nyj'},
                 {'boxscore': '201710290nwe',
+                 'league': 'NFL',
                  'away_name': 'Los Angeles Chargers',
                  'away_abbr': 'sdg',
                  'away_score': 13,
@@ -590,6 +652,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Los Angeles Chargers',
                  'losing_abbr': 'sdg'},
                 {'boxscore': '201710290nor',
+                 'league': 'NFL',
                  'away_name': 'Chicago Bears',
                  'away_abbr': 'chi',
                  'away_score': 12,
@@ -601,6 +664,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Chicago Bears',
                  'losing_abbr': 'chi'},
                 {'boxscore': '201710290cin',
+                 'league': 'NFL',
                  'away_name': 'Indianapolis Colts',
                  'away_abbr': 'clt',
                  'away_score': 23,
@@ -612,6 +676,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Indianapolis Colts',
                  'losing_abbr': 'clt'},
                 {'boxscore': '201710290sea',
+                 'league': 'NFL',
                  'away_name': 'Houston Texans',
                  'away_abbr': 'htx',
                  'away_score': 38,
@@ -623,6 +688,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Houston Texans',
                  'losing_abbr': 'htx'},
                 {'boxscore': '201710290was',
+                 'league': 'NFL',
                  'away_name': 'Dallas Cowboys',
                  'away_abbr': 'dal',
                  'away_score': 33,
@@ -634,6 +700,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Washington Redskins',
                  'losing_abbr': 'was'},
                 {'boxscore': '201710290det',
+                 'league': 'NFL',
                  'away_name': 'Pittsburgh Steelers',
                  'away_abbr': 'pit',
                  'away_score': 20,
@@ -645,6 +712,7 @@ class TestNFLBoxscores:
                  'losing_name': 'Detroit Lions',
                  'losing_abbr': 'det'},
                 {'boxscore': '201710300kan',
+                 'league': 'NFL',
                  'away_name': 'Denver Broncos',
                  'away_abbr': 'den',
                  'away_score': 19,

--- a/tests/integration/teams/test_nba_integration.py
+++ b/tests/integration/teams/test_nba_integration.py
@@ -30,7 +30,7 @@ def mock_request(url):
         return MockRequest('bad', status_code=404)
 
 
-def mock_pyquery(url):
+def mock_pyquery(url, *args, **kwargs):
     class MockPQ:
         def __init__(self, html_contents):
             self.status_code = 200
@@ -44,6 +44,7 @@ def mock_pyquery(url):
                 return read_file('%s_opponent.html' % YEAR)
 
     html_contents = read_file('NBA_%s.html' % YEAR)
+
     return MockPQ(html_contents)
 
 
@@ -81,6 +82,7 @@ class TestNBAIntegration:
             'steals': 574,
             'blocks': 310,
             'turnovers': 973,
+            'league': 'NBA',
             'personal_fouls': 1467,
             'points': 8309,
             'opp_field_goals': 3144,
@@ -172,6 +174,27 @@ class TestNBAIntegration:
 
         for attribute, value in self.results.items():
             assert getattr(detroit, attribute) == value
+
+    def test_league_specifications(self, *args, **kwargs):
+        year_to_leagues = {
+            1961: ['NBA'],
+            1947: ['BAA'],
+            1970: ['NBA', 'ABA'],
+            2000: ['NBA']
+        }
+
+        for year, leagues in year_to_leagues.items():
+            month = 12
+            flexmock(utils)\
+                .should_receive('_todays_date')\
+                .and_return(MockDateTime(year, month))
+            teams = Teams()
+
+            assert all(t.league in leagues for t in teams._teams)
+
+            teams_one_league = Teams(leagues=[leagues[0]])
+
+            assert all(t.league == leagues[0] for t in teams_one_league._teams)
 
 
 class TestNBAIntegrationInvalidDate:


### PR DESCRIPTION
Previously, for some years which had multiple leagues, only results
from the primary league (i.e. NFL or NBA) were considered for both
NFL and NBA. This allows the user to specify which appropriate leagues
to use.

This is a pretty extensive change and I am definitely open to any changes in the structure of the code here or what the defaults should be, or if these should be included at all. 

These changes had been helpful to me, and I wanted to help to contribute this to others in case others wanted to use this as well. 

This was considered because of some historical data for both American football and Basketball leagues. If a year was considered with multiple leagues (for instance, 1968-1976 there was both the "NBA" and the "ABA" for basketball) or with a single league that isn't the "primary" (like the "BAA" for games pre-1949), previously this would only return the results for the primary league, if it exists, or would return an error if it did not. 

This pull request updates this behavior for `Teams` and `Boxscores`, where appropriate for the `nfl` and `nba` classes.

For instance, if you were to run the following code previously, an HTTPError be raised, throwing a `404` error:

```python
from sportsreference.nba.team import Teams
t = Teams(1947)
```
This was because the only league at this time was not the NBA. This happens functionally because the following link does not exist: [https://www.basketball-reference.com/leagues/NBA_1947.html](https://www.basketball-reference.com/leagues/NBA_1947.html). However, there is a link for the [BAA](https://www.basketball-reference.com/leagues/BAA_1947.html) that is a valid link. 

Now, 
```python
from sportsreference.nba.team import Teams
t = Teams(1947)
```
will return results from the BAA.

With the feature added in this PR, there is now an additional argument for `Teams`, `Team` and `Boxscores` (for NFL) called `leagues` that is a list that will allow one to specify which leagues they are referring to. 

If no leagues are passed, all of the teams from all of the leagues are returned. This is behavior I was curious about your thoughts on -- I can also have it simply default to the "primary" league (['NBA'] or ['NFL']). 

Previous behavior is retained by calling the following: 

Now, 
```python
from sportsreference.nba.team import Teams
t = Teams(1947, leagues=['NBA'])
```

This will return the same HTTP Error. 

Additionally, If we considered 1968 in the current HEAD, only results from the NBA would be returned:

```python
t = Teams(1968)
print(t.dataframes)
```
returns
```
    abbreviation  assists blocks  ... two_point_field_goal_attempts  two_point_field_goal_percentage  two_point_field_goals
PHI          PHI     2197   None  ...                          8414                            0.471                   3965
LAL          LAL     1983   None  ...                          8031                            0.477                   3827
SEA          SEA     1998   None  ...                          8593                            0.439                   3772
DET          DET     1700   None  ...                          8386                            0.448                   3755
BAL          BAL     1534   None  ...                          8428                            0.438                   3691
SFW          SFW     1901   None  ...                          8587                            0.423                   3632
CIN          CIN     2048   None  ...                          7864                            0.468                   3679
BOS          BOS     1798   None  ...                          8371                            0.440                   3686
NYK          NYK     1967   None  ...                          8070                            0.456                   3682
STL          STL     1988   None  ...                          7765                            0.451                   3504
SDR          SDR     1837   None  ...                          8547                            0.417                   3566
CHI          CHI     1527   None  ...                          8138                            0.429                   3488

[12 rows x 48 columns]
```


These are only NBA teams, but there were also ABA teams this year as well. 

The same code produces the following in this PR: 

```
    abbreviation  assists blocks  ... two_point_field_goal_attempts  two_point_field_goal_percentage  two_point_field_goals
PHI          PHI     2197   None  ...                          8414                            0.471                   3965
LAL          LAL     1983   None  ...                          8031                            0.477                   3827
SEA          SEA     1998   None  ...                          8593                            0.439                   3772
DET          DET     1700   None  ...                          8386                            0.448                   3755
BAL          BAL     1534   None  ...                          8428                            0.438                   3691
SFW          SFW     1901   None  ...                          8587                            0.423                   3632
CIN          CIN     2048   None  ...                          7864                            0.468                   3679
BOS          BOS     1798   None  ...                          8371                            0.440                   3686
NYK          NYK     1967   None  ...                          8070                            0.456                   3682
STL          STL     1988   None  ...                          7765                            0.451                   3504
SDR          SDR     1837   None  ...                          8547                            0.417                   3566
CHI          CHI     1527   None  ...                          8138                            0.429                   3488
PTP          PTP     1239   None  ...                          6738                            0.443                   2987
NOB          NOB     1355   None  ...                          7301                            0.432                   3154
ANA          ANA     1297   None  ...                          6890                            0.429                   2953
OAK          OAK     1149   None  ...                          7327                            0.425                   3112
NJA          NJA     1200   None  ...                          7271                            0.421                   3064
DLC          DLC     1344   None  ...                          7047                            0.458                   3231
INA          INA     1176   None  ...                          7037                            0.437                   3078
MNM          MNM     1019   None  ...                          7813                            0.406                   3171
DNR          DNR     1044   None  ...                          7122                            0.434                   3094
KEN          KEN     1165   None  ...                          6966                            0.417                   2903
HSM          HSM     1175   None  ...                          7342                            0.406                   2982

[23 rows x 48 columns]
```

This may seem like undesired behavior, since the ABA is now defunct, but because some teams from the ABA are currently in the NBA, it may be of interest to see these teams. 

To keep the previous behavior with the addition of this feature, one could run the following:

```python
t = Teams(1968, leagues=['NBA'])
print(t.dataframes)
```

A few additional things which were added:

* A "league" attribute was added to Team objects
* A "league" column was added to the dataframes objects 

Finally, there is the `Boxscores` objects. 

For the NBA, all leagues are listed on one page for the Boxscore, meaning that it is not necessary to change the code for these. To see this, look at the following URLS:

With the BAA (1947): 
https://www.basketball-reference.com/boxscores/?month=12&day=4&year=1947
With the NBA and ABA (1968): 
https://www.basketball-reference.com/boxscores/?month=11&day=4&year=1968
 
For the NFL, the Boxscores object needed to be updated to account for the different leagues. 

For instance, for 1960 there are two separate pages:
 
AFL 
https://www.pro-football-reference.com/years/1960_AFL/week_1.htm

NFL
https://www.pro-football-reference.com/years/1960/week_1.htm

This is handled by creating a list of different urls for each league and performing the same operations. 

That was a lot, thanks for reading! Again, this is quite a big number of changes and I understand if the functionality is not strongly desired or needed (surely, keeping it within the "primary" league is most relevant for recent games), I figured I would make a PR since I found this useful for the older games and others may as well. 

Thanks! Happy to discuss any ideas regarding tests, the structure, etc. 