### PR TITLE
Fix failing NCAAB game summary

### DIFF
--- a/sportsipy/ncaab/boxscore.py
+++ b/sportsipy/ncaab/boxscore.py
@@ -616,7 +616,7 @@ class Boxscore:
             # Only pull the first N-1 items as the last element is the final
             # score for each team which is already stored in an attribute, and
             # shouldn't be duplicated.
-            for half in list(team_info('td[class="right"]').items())[:-1]:
+            for half in list(team_info('td[class*="center"]').items())[:-1]:
                 ind = ind % 2
                 try:
                     summary[team[ind]].append(int(half.text()))

--- a/tests/unit/test_ncaab_boxscore.py
+++ b/tests/unit/test_ncaab_boxscore.py
@@ -311,26 +311,48 @@ class TestNCAABBoxscore:
         type(self.boxscore)._home_record = fake_record
 
         assert self.boxscore.home_losses == 0
-
     def test_game_summary_with_no_scores_returns_none(self):
         result = Boxscore(None)._parse_summary(pq(
             """<table id="line-score">
-    <tbody>
-        <tr>
-            <td class="right"></td>
-            <td class="right"></td>
-        </tr>
-        <tr>
-            <td class="right"></td>
-            <td class="right"></td>
-        </tr>
-    </tbody>
-</table>"""
+                <tbody>
+                    <tr>
+                        <td class="center"></td>
+                        <td class="center"></td>
+                        <td class="center"></td>
+                    </tr>
+                    <tr>
+                        <td class="center"></td>
+                        <td class="center"></td>
+                        <td class="center"></td>
+                    </tr>
+                </tbody>
+            </table>"""
         ))
-
         assert result == {
             'away': [None],
             'home': [None]
+        }
+
+    def test_game_summary_with_scores_returns_summary(self):
+        result = Boxscore(None)._parse_summary(pq(
+            """<table id="line-score">
+                <tbody>
+                    <tr>
+                        <td class="center">25</td>
+                        <td class="center">46</td>
+                        <td class="center">71</td>
+                    </tr>
+                    <tr>
+                        <td class="center">45</td>
+                        <td class="center">33</td>
+                        <td class="center">78</td>
+                    </tr>
+                </tbody>
+            </table>"""
+        ))
+        assert result == {
+            'away': [25, 46],
+            'home': [45, 33]
         }
 
     def test_invalid_url_returns_none(self):


### PR DESCRIPTION
The NCAAB game summary returns a blank dict because of change in html, this commit
updates the html parsing and adds regression testing for issues.

Signed-Off-By: Kent Schwartz kentsch@gmail.com

closes #577 
