### PR TITLE
Add missing NBA table_ids in Player

### DIFF
--- a/sportsipy/nba/roster.py
+++ b/sportsipy/nba/roster.py
@@ -329,8 +329,14 @@ class Player(AbstractPlayer):
         """
         all_stats_dict = {}
 
-        for table_id in ['totals', 'per_poss', 'advanced', 'shooting',
-                         'advanced_pbp', 'all_salaries']:
+        # Missing because result in StopIteration: 'sim_thru', 'sim_career'
+        for table_id in ['per_game', 'totals', 'per_minute', 'per_poss',
+                         'advanced', 'adj_shooting', 'shooting', 'pbp',
+                         'game_highs', 'playoffs_per_game', 'playoffs_totals',
+                         'playoffs_per_minute', 'playoffs_per_poss',
+                         'playoffs_advanced', 'playoffs_shooting',
+                         'playoffs_pbp', 'game_highs_po', 'all_star', 
+                         'all_college_stats', 'all_salaries']:
             table_items = utils._get_stats_table(player_info,
                                                  'table#%s' % table_id)
             career_items = utils._get_stats_table(player_info,


### PR DESCRIPTION
Hi @roclark ,

Thanks for this amazing repo!

I noticed that some tables on NBA player pages were not being loaded. I've added in the missing tables, except for two which result in errors and will need a bit more work - these are indicated in the code.

From a quick glance, the following stats were previously not loaded or loaded as 0s and are now fixed:
`lost_ball_turnovers, offensive_fouls, points_generated_by_assists, passing_turnovers, shooting_fouls, net_plus_minus, and_ones, on_court_plus_minus, shooting_fouls_drawn, center_percentage, point_guard_percentage, power_forward_percentage, shooting_guard_percentage, small_forward_percentage`.

Some of the tables I've added won't yet have the data loaded since the appropriate fields aren't yet listed (e.g. playoff information for #425), but that seems to merit a separate Pull Request.

Wasn't sure if there was anything to add to the documentation/test suite based on these changes.

Look forward to hearing your thoughts,

Ethan Baron