### PR TITLE
Increase testing workers

### DIFF
--- a/.github/workflows/pushtests.yml
+++ b/.github/workflows/pushtests.yml
@@ -23,7 +23,7 @@ jobs:
         pip install -r requirements.txt
     - name: Run unit and integration tests with pytest
       run: |
-        py.test --cov=sportsipy --cov-report term-missing --cov-report xml tests/integration/ tests/unit/
+        pytest -n 4 --cov=sportsipy --cov-report term-missing --cov-report xml tests/integration/ tests/unit/
     - name: Lint with pycodestyle
       run: |
         pycodestyle sportsipy/ tests/integration/ tests/unit/

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ pyparsing==2.4.7
 pyquery==1.4.0
 pytest==6.2.1
 pytest-cov==2.10.1
+pytest-xdist==2.3.0
 python-dateutil==2.8.1
 pytz==2020.5
 requests==2.25.1


### PR DESCRIPTION
By increasing the number of workers available for pytest, the testing can complete faster for better turnarounds.

Signed-Off-By: Robert Clark <robdclark@outlook.com>