### PR TITLE
Fix issue pulling default year for NBA

### DIFF
--- a/tests/unit/test_nba_utils.py
+++ b/tests/unit/test_nba_utils.py
@@ -20,8 +20,8 @@ def mock_pyquery(url):
     if '2021' in url:
         return MockPQ('<div/>', status_code=404)
     else:
-        return MockPQ('<div id="all_team-stats-base"/>'
-                      '<div id="all_opponent-stats-base"/>')
+        return MockPQ('<div id="div_totals-team"/>'
+                      '<div id="div_totals-opponent"/>')
 
 
 class TestNBAUtils:


### PR DESCRIPTION
Given the format of the NBA pages changed on the website, the unit tests need to be updated to pull the default year for 2020 given the scheduling is different for that year.

Signed-Off-By: Robert Clark <robdclark@outlook.com>