### PR TITLE
Fix empty NFL Rosters

### DIFF
--- a/sportsipy/nfl/roster.py
+++ b/sportsipy/nfl/roster.py
@@ -1867,7 +1867,7 @@ class Roster:
             output = ("Can't pull requested team page. Ensure the following "
                       "URL exists: %s" % url)
             raise ValueError(output)
-        for player in page('table#games_played_team tbody tr').items():
+        for player in page('table#roster tbody tr').items():
             player_id = self._get_id(player)
             if self._slim:
                 name = self._get_name(player)


### PR DESCRIPTION
Currently, when trying to get the roster for a given NFL team, the
result is an empty list. The reason for this is because the html element
that is being used to search within the roster html page is incorrect.
When changing that element to an element that exists on the page, we get
the correct results for an NFL roster.

Example: 
roster = Roster("WAS")
print(roster)
["Kendall Fuller", ...]

Signed-Off-By: Alec Keller <alec.keller.17@gmail.com>

closes #677 
