### PR TITLE
Revert numpy version for Python 3.7 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ chardet==4.0.0
 cssselect==1.1.0
 idna==2.9
 lxml==4.8.0
-numpy==1.22.2
+numpy==1.21.5
 pandas==0.25.3
 pyquery==1.4.0
 python-dateutil==2.8.1


### PR DESCRIPTION
The updated version of numpy is incompatible with Python 3.7 and causes tests with that Python version to fail. Reverting to the latest version supported by Python 3.7 resolves the issue.

Signed-Off-By: Robert Clark <robdclark@outlook.com>