### PR TITLE
Remove windows-2016 OS from GitHub Actions

### DIFF
--- a/.github/workflows/pushtests.yml
+++ b/.github/workflows/pushtests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8]
-        operating-system: [ubuntu-latest, macOS-latest, windows-latest, windows-2016]
+        operating-system: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
The windows-2016 OS is deprecated on GitHub Actions and will automatically be cancelled for any jobs that are run against it.

Signed-Off-By: Robert Clark <robdclark@outlook.com>