### PR TITLE
Fix the baseball example in the index.rst file

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -81,7 +81,7 @@ Get a Pandas DataFrame of all stats for a MLB game
 
     from sportsipy.mlb.boxscore import Boxscore
 
-    game = Boxscore('BOS201806070')
+    game = Boxscore('BOS/BOS201806070')
     df = game.dataframe
 
 Find the number of goals a football team has scored


### PR DESCRIPTION
Fix the baseball code example

It currently results in an empty dataframe, which is useless.  The string passed as argument to the Boxscore class is incorrect, and requires the `BOS/` at the beginning.
